### PR TITLE
Add AdjustWindowRect calls to "samples", this fixes a bug where the client area window size ends up being incorrect

### DIFF
--- a/samples/rotating_quad/main.go
+++ b/samples/rotating_quad/main.go
@@ -33,12 +33,20 @@ func main() {
 		ClassName: classNamePtr,
 	})
 
+	windowStyle := uint(w32.WS_OVERLAPPEDWINDOW | w32.WS_VISIBLE)
+	windowRect := w32.RECT{
+		Left:   0,
+		Top:    0,
+		Right:  640,
+		Bottom: 480,
+	}
+	w32.AdjustWindowRect(&windowRect, windowStyle, false)
 	windowNamePtr, _ := syscall.UTF16PtrFromString("Rotating Quad")
 	windowHandle := w32.CreateWindow(
 		classNamePtr,
 		windowNamePtr,
-		w32.WS_OVERLAPPEDWINDOW|w32.WS_VISIBLE,
-		w32.CW_USEDEFAULT, w32.CW_USEDEFAULT, 640, 480,
+		windowStyle,
+		w32.CW_USEDEFAULT, w32.CW_USEDEFAULT, int(windowRect.Width()), int(windowRect.Height()),
 		0, 0, 0, nil,
 	)
 

--- a/samples/simple_glow/main.go
+++ b/samples/simple_glow/main.go
@@ -32,12 +32,20 @@ func main() {
 		ClassName: classNamePtr,
 	})
 
+	windowStyle := uint(w32.WS_OVERLAPPEDWINDOW | w32.WS_VISIBLE)
+	windowRect := w32.RECT{
+		Left:   0,
+		Top:    0,
+		Right:  640,
+		Bottom: 480,
+	}
+	w32.AdjustWindowRect(&windowRect, windowStyle, false)
 	windowNamePtr, _ := syscall.UTF16PtrFromString("Simple Glow")
 	windowHandle := w32.CreateWindow(
 		classNamePtr,
 		windowNamePtr,
-		w32.WS_OVERLAPPEDWINDOW|w32.WS_VISIBLE,
-		w32.CW_USEDEFAULT, w32.CW_USEDEFAULT, 640, 480,
+		windowStyle,
+		w32.CW_USEDEFAULT, w32.CW_USEDEFAULT, int(windowRect.Width()), int(windowRect.Height()),
 		0, 0, 0, nil,
 	)
 

--- a/samples/static_triangle/main.go
+++ b/samples/static_triangle/main.go
@@ -32,12 +32,20 @@ func main() {
 		ClassName: classNamePtr,
 	})
 
+	windowStyle := uint(w32.WS_OVERLAPPEDWINDOW | w32.WS_VISIBLE)
+	windowRect := w32.RECT{
+		Left:   0,
+		Top:    0,
+		Right:  640,
+		Bottom: 480,
+	}
+	w32.AdjustWindowRect(&windowRect, windowStyle, false)
 	windowNamePtr, _ := syscall.UTF16PtrFromString("Static Triangle")
 	windowHandle := w32.CreateWindow(
 		classNamePtr,
 		windowNamePtr,
-		w32.WS_OVERLAPPEDWINDOW|w32.WS_VISIBLE,
-		w32.CW_USEDEFAULT, w32.CW_USEDEFAULT, 640, 480,
+		windowStyle,
+		w32.CW_USEDEFAULT, w32.CW_USEDEFAULT, int(windowRect.Width()), int(windowRect.Height()),
 		0, 0, 0, nil,
 	)
 


### PR DESCRIPTION
Add AdjustWindowRect calls to "samples", this fixes a bug where the client area window size ends up being incorrect

Fixes #11